### PR TITLE
Add Jest setup and DOM-based unit tests

### DIFF
--- a/__tests__/copy.test.js
+++ b/__tests__/copy.test.js
@@ -1,0 +1,28 @@
+/**
+ * @jest-environment jsdom
+ */
+const { copyCode } = require('../js/copy');
+
+describe('copyCode', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    document.body.innerHTML = `
+      <div class="code-block">
+        <pre>console.log('hi')</pre>
+        <button class="copy-btn">Copiar</button>
+      </div>
+      <div id="aria-live"></div>
+    `;
+    global.navigator.clipboard = {
+      writeText: jest.fn().mockResolvedValue()
+    };
+  });
+
+  test('copies text and shows feedback', async () => {
+    const button = document.querySelector('.copy-btn');
+    await copyCode(button);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("console.log('hi')");
+    expect(button.innerHTML).toContain('Copiado!');
+    expect(document.getElementById('aria-live').textContent).toBe('Código copiado para a área de transferência.');
+  });
+});

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment jsdom
+ */
+const { loadAulas } = require('../js/main');
+
+describe('loadAulas', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="cards-container"></div>';
+  });
+
+  test('renders cards from fetched aulas', async () => {
+    const sample = [
+      { arquivo: 'aula1.html', titulo: 'Aula 1: Intro', descricao: 'Desc', ativo: true }
+    ];
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve(sample) })
+    );
+    await loadAulas();
+    const cards = document.querySelectorAll('#cards-container a');
+    expect(cards.length).toBe(1);
+    expect(cards[0].textContent).toContain('Aula 1');
+  });
+});

--- a/js/copy.js
+++ b/js/copy.js
@@ -1,0 +1,20 @@
+function copyCode(button) {
+  const codeBlock = button.closest('.code-block');
+  if (!codeBlock) return Promise.resolve();
+  const codeToCopy = codeBlock.querySelector('pre').innerText;
+  return navigator.clipboard.writeText(codeToCopy).then(() => {
+    const originalText = button.innerHTML;
+    button.innerHTML = '<i class="fa-solid fa-check mr-1"></i>Copiado!';
+    const live = document.getElementById('aria-live');
+    if (live) {
+      live.textContent = 'Código copiado para a área de transferência.';
+    }
+    setTimeout(() => {
+      button.innerHTML = originalText;
+    }, 2000);
+  });
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { copyCode };
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1474,3 +1474,8 @@ function setupTheme() {
     });
   }
 }
+
+
+if (typeof module !== 'undefined') {
+  module.exports = { loadAulas, initAdvancedCopyButtons };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "lpoo",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "license": "ISC",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^24.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- setup Jest with jsdom for testing
- add copyCode utility and export functions for testing
- test copy feedback and card rendering

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2721de64832cbf61a6316e183c83